### PR TITLE
adding consistency to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ class ControlledInput extends React.Component {
     };
   }
   
-  handleChange(ev) {
+  handleChange(event) {
     this.setState({
-      value: ev.target.value,
+      value: event.target.value,
     });
   }
 


### PR DESCRIPTION
changed `ev` to be `event` in the README.md, since that is what we have used throughout the entire course. @aturkewi @PeterBell @AnnJohn 
